### PR TITLE
Fixed dashed variable names

### DIFF
--- a/syntaxes/gbnf.tmLanguage.json
+++ b/syntaxes/gbnf.tmLanguage.json
@@ -14,7 +14,7 @@
   "repository": {
     "variables": {
       "name": "variable.language",
-      "match": "\\b[a-zA-Z_][a-zA-Z_0-9]*\\b(?=\\s*::=)"
+      "match": "\\b[a-zA-Z\-][a-zA-Z\-0-9]*\\b(?=\\s*::=)"
     },
     "assignment": {
       "name": "keyword.operator.assignment",
@@ -31,7 +31,7 @@
     },
     "identifiers": {
       "name": "variable.identifier",
-      "match": "\\b[a-zA-Z_][a-zA-Z_0-9]*\\b"
+      "match": "\\b[a-zA-Z\-][a-zA-Z\-0-9]*\\b"
     },
     "comments": {
       "name": "comment.line",


### PR DESCRIPTION
GBNF uses dashes for variable names instead of underscores. Changed the regex to reflect this.